### PR TITLE
Fix: support Python 3

### DIFF
--- a/src/WebSocketClient/__init__.py
+++ b/src/WebSocketClient/__init__.py
@@ -1,5 +1,5 @@
-from keywords import WebSocketClientKeywords
-from version import VERSION
+from .keywords import WebSocketClientKeywords
+from .version import VERSION
 
 _version_ = VERSION
 


### PR DESCRIPTION
Hi,

This resolves `ImportError: No module named 'keywords'` on Python 3 because [explicit relative imports are mandatory](http://portingguide.readthedocs.io/en/latest/imports.html#absolute-imports).

Thanks for the library!